### PR TITLE
Fix vscode-extension-release workflow about vsce

### DIFF
--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -28,5 +28,5 @@ jobs:
           generate_release_notes: true
           tag_name: ${{ steps.tag-new-version.outputs.tag }}
         if: ${{ steps.tag-new-version.outputs.tag }}
-      - run: npx vsce publish --pat ${{ secrets.vsce-token }}
+      - run: npx @vscode/vsce publish --pat ${{ secrets.vsce-token }}
         if: ${{ steps.tag-new-version.outputs.tag }}


### PR DESCRIPTION
`vsce` has been renamed to `@vscode/vsce`.

```
Run npx vsce publish --pat ***

npm WARN exec The following package was not found and will be installed: vsce@2.15.0
npm WARN deprecated vsce@2.15.0: vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.
Error: Manifest needs the 'activationEvents' property, given it has a 'main' property.
Error: Process completed with exit code 1.
```
